### PR TITLE
Add fuzz tests for Encrypt and Decrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
 *.test
 *.pprof
-
-# Ignore seed corpus entries for these tests as we already have entries in tests
-# directly.
-testdata/fuzz/FuzzEncryptDecrypt
-testdata/fuzz/FuzzEncryptOrderedPairs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.test
 *.pprof
+
+# Ignore seed corpus entries for these tests as we already have entries in tests
+# directly.
+testdata/fuzz/FuzzEncryptDecrypt
+testdata/fuzz/FuzzEncryptOrderedPairs

--- a/ordenc_fuzz_test.go
+++ b/ordenc_fuzz_test.go
@@ -68,9 +68,9 @@ func FuzzEncryptOrderedPairs(f *testing.F) {
 		e1 := Encrypt(k, p1, nil)
 		e2 := Encrypt(k, p2, nil)
 
-		// t.Logf("p1=%s / p2=%s", string(p1), string(p2))
-		// t.Logf("e1=%s / e2=%s", string(e1), string(e2))
+		// t.Logf("p1=%v / p2=%v", p1, p2)
+		// t.Logf("e1=%v / e2=%v", e1, e2)
 
-		assert.That(t, bytes.Compare(p1, p2) == bytes.Compare(e1, e2))
+		assert.Equal(t, bytes.Compare(p1, p2), bytes.Compare(e1, e2))
 	})
 }

--- a/ordenc_fuzz_test.go
+++ b/ordenc_fuzz_test.go
@@ -4,6 +4,7 @@
 package ordenc
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/zeebo/assert"
@@ -70,12 +71,6 @@ func FuzzEncryptOrderedPairs(f *testing.F) {
 		// t.Logf("p1=%s / p2=%s", string(p1), string(p2))
 		// t.Logf("e1=%s / e2=%s", string(e1), string(e2))
 
-		if string(p1) < string(p2) {
-			assert.That(t, string(e1) < string(e2))
-		} else if string(p1) > string(p2) {
-			assert.That(t, string(e1) > string(e2))
-		} else {
-			assert.That(t, string(e1) == string(e2))
-		}
+		assert.That(t, bytes.Compare(p1, p2) == bytes.Compare(e1, e2))
 	})
 }

--- a/ordenc_fuzz_test.go
+++ b/ordenc_fuzz_test.go
@@ -1,0 +1,81 @@
+//go:build go1.18
+// +build go1.18
+
+package ordenc
+
+import (
+	"testing"
+
+	"github.com/zeebo/assert"
+	"github.com/zeebo/mwc"
+)
+
+func FuzzEncryptDecrypt(f *testing.F) {
+	rng := mwc.Rand()
+
+	k, err := NewRandomKey(&rng)
+	assert.NoError(f, err)
+
+	for _, s := range [...][]byte{ // Add paths to the seed corpus.
+		[]byte("sample.jpg"),
+		[]byte("photos/2022/January/dog.jpg"),
+		[]byte("photos/2022/February/dog2.jpg"),
+		[]byte("photos/2022/February/dog3.jpg"),
+		[]byte("photos/2022/February/dog4.jpg"),
+	} {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		e := Encrypt(k, input, nil)
+
+		d, ok := Decrypt(k, e, nil)
+
+		assert.That(t, ok)
+		assert.Equal(t, input, d)
+	})
+}
+
+func FuzzEncryptOrderedPairs(f *testing.F) {
+	rng := mwc.Rand()
+
+	k, err := NewRandomKey(&rng)
+	assert.NoError(f, err)
+
+	for _, s := range [...][2][]byte{ // Add pairs to the seed corpus.
+		{
+			[]byte("photos/2022/January/dog.jpg"),
+			[]byte("sample.jpg"),
+		},
+		{
+			[]byte("photos/2022/February/dog2.jpg"),
+			[]byte("photos/2022/January/dog.jpg"),
+		},
+		{
+			[]byte("photos/2022/February/dog2.jpg"),
+			[]byte("photos/2022/February/dog3.jpg"),
+		},
+		{
+			[]byte("photos/2022/February/dog3.jpg"),
+			[]byte("photos/2022/February/dog4.jpg"),
+		},
+	} {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, p1, p2 []byte) {
+		e1 := Encrypt(k, p1, nil)
+		e2 := Encrypt(k, p2, nil)
+
+		// t.Logf("p1=%s / p2=%s", string(p1), string(p2))
+		// t.Logf("e1=%s / e2=%s", string(e1), string(e2))
+
+		if string(p1) < string(p2) {
+			assert.That(t, string(e1) < string(e2))
+		} else if string(p1) > string(p2) {
+			assert.That(t, string(e1) > string(e2))
+		} else {
+			assert.That(t, string(e1) == string(e2))
+		}
+	})
+}

--- a/testdata/fuzz/FuzzEncryptOrderedPairs/a1c592ff96520a9c6c4d92d36d9207db8634815bb75ea8b19d6faacbd32222d4
+++ b/testdata/fuzz/FuzzEncryptOrderedPairs/a1c592ff96520a9c6c4d92d36d9207db8634815bb75ea8b19d6faacbd32222d4
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("photos/")
+[]byte("photos/0")


### PR DESCRIPTION
This PR adds tests to fuzz 'em.

I have run `FuzzEncryptDecrypt` for quite some time now, but `FuzzEncryptOrderedPairs` fails on cases where `p\xb2otos/ < p\xb2otos/0` and `Encrypt` produces output that does not satisfy the `<` condition.